### PR TITLE
Match implementations of `sensor.qfi` with Eq. 4 in the arxiv paper

### DIFF
--- a/queso/sensors/pennylane/sensor.py
+++ b/queso/sensors/pennylane/sensor.py
@@ -133,7 +133,7 @@ class Sensor:
             * jnp.real(
                 (
                     jnp.conj(dpsi[None, :]) @ dpsi[:, None]
-                    - jnp.abs(jnp.conj(dpsi[None, :]) @ psi[:, None])
+                    - jnp.abs(jnp.conj(dpsi[None, :]) @ psi[:, None])**2
                 )
             ).squeeze()
         )

--- a/queso/sensors/tc/sensor.py
+++ b/queso/sensors/tc/sensor.py
@@ -150,7 +150,7 @@ class Sensor:
             * jnp.real(
                 (
                     jnp.conj(dpsi[None, :]) @ dpsi[:, None]
-                    - jnp.abs(jnp.conj(dpsi[None, :]) @ psi[:, None])
+                    - jnp.abs(jnp.conj(dpsi[None, :]) @ psi[:, None])**2
                 )
             ).squeeze()
         )


### PR DESCRIPTION
The absolute value term in the implementation of the QFI for sensors was not squared.